### PR TITLE
Don't include netlify identity widget on main site

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -18,9 +18,7 @@ export default {
     Content
   },
   head() {
-    return {
-      script: [{ src: 'https://identity.netlify.com/v1/netlify-identity-widget.js' }]
-    }
+    return {}
   }
 }
 </script>


### PR DESCRIPTION
**Still loads on /admin**
<img width="1440" alt="Screenshot 2020-11-27 at 22 14 17" src="https://user-images.githubusercontent.com/805377/100484888-72c0da80-30fe-11eb-88e1-41bbabcd2fa3.png">

**Improved performance**
<img width="726" alt="Screenshot 2020-11-27 at 22 17 03" src="https://user-images.githubusercontent.com/805377/100484907-7d7b6f80-30fe-11eb-9bc1-6173c6b09f72.png">
